### PR TITLE
Shorten waiting timeout for no target or package

### DIFF
--- a/main.go
+++ b/main.go
@@ -209,7 +209,7 @@ func main() {
 		}
 		if target == -1 {
 			fmt.Println("No new targets, waiting...")
-			<-time.After(time.Minute * 30)
+			<-time.After(time.Minute * 3)
 			continue
 		}
 
@@ -254,7 +254,7 @@ func main() {
 		}
 		if counter == -1 {
 			fmt.Println("No new packages, waiting...")
-			<-time.After(time.Minute * 30)
+			<-time.After(time.Minute * 3)
 			continue
 		}
 		fmt.Printf("Calculating package %d\n", counter)


### PR DESCRIPTION
Shortened the timeout from 30 minutes to 3 minutes.

I was getting the no new targets message, but restarting gets new data with no problem.
It might be more to do with network traffic.